### PR TITLE
Make sure to initialize search result before returning it

### DIFF
--- a/src/dsearchthread.cpp
+++ b/src/dsearchthread.cpp
@@ -220,7 +220,7 @@ void DSearchThread::run()
         bool startFound = m_CurrentPage == 0;
 
         // Could consider launching one thread per root node here...
-        SearchResult res;
+        SearchResult res = SEARCH_UNDEFINED;
         unsigned int c = m_Model->rootCount();
         for ( unsigned int i = 0; i < c; i++ )
         {


### PR DESCRIPTION
The compiler complained that the 'res' variable can be used without
being initialized.  To make sure this do not happen, I defined it to
the undefined value when it is decleared.