### PR TITLE
Index content of plain text files too

### DIFF
--- a/src/dattachmentindexer.h
+++ b/src/dattachmentindexer.h
@@ -79,6 +79,7 @@ private:
     bool                   m_Error;
 
     friend class DPdf2Txt;
+    friend class DText;
 
 };
 


### PR DESCRIPTION
Add new DAttachmentIndexer() helper class DText.  It reads plain text files
and add their context to the search index.