### PR TITLE
Register DNS name for organization with QApplication.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,6 +118,7 @@ int  main( int argc, char* argv[] )
     // Create application object
     QApplication qtApp( argc, argv );
     qtApp.setOrganizationName( "Piql" );
+    qtApp.setOrganizationDomain("piql.com");
     qtApp.setApplicationName( "insight" );
     qtApp.setApplicationVersion( "v1.0.0-rc1" );
 


### PR DESCRIPTION
This DNS name can be used by QSettings on MacOSX.  At the moment it is
not used, but it seem to make sense to set it anyway for future reference.