### PR TITLE
Make configuration handling on non-windows multi-level (Qt default ini)

### DIFF
--- a/src/dinsightconfig.cpp
+++ b/src/dinsightconfig.cpp
@@ -28,7 +28,20 @@
  *  Handles config file settings.
  *  
  */
- 
+
+#ifdef _WIN32
+// Stay compatible with released Windows version, looking for insight.conf
+// file only in current working directory
+#  define SETTINGS QSettings( defaultFileName(), QSettings::IniFormat )
+#else // _WIN32
+// Use default Qt behaviour elsewhere, looking for insight.ini in
+// /usr/share/, /etc/ and ~/.config/ on unix and MacOS.
+#  define SETTINGS QSettings( QSettings::IniFormat, \
+                              QSettings::UserScope, \
+                              QCoreApplication::organizationName(),\
+                              QCoreApplication::applicationName())
+#endif // _WIN32
+
 //===================================
 //  P U B L I C   I N T E R F A C E
 //===================================
@@ -41,7 +54,7 @@
 
 QString DInsightConfig::get( const QString& key, const QString& def /*= ""*/ )
 {
-    return QSettings( defaultFileName(), QSettings::IniFormat ).value( key, def ).toString();
+    return SETTINGS.value( key, def ).toString();
 }
 
 
@@ -52,7 +65,7 @@ QString DInsightConfig::get( const QString& key, const QString& def /*= ""*/ )
 
 int DInsightConfig::getInt( const QString& key, int def /*= -1*/ )
 {
-    return QSettings( defaultFileName(), QSettings::IniFormat ).value( key, def ).toInt();
+    return SETTINGS.value( key, def ).toInt();
 }
 
 
@@ -63,7 +76,7 @@ int DInsightConfig::getInt( const QString& key, int def /*= -1*/ )
 
 bool DInsightConfig::getBool( const QString& key, bool def /*= false*/ )
 {
-    return QSettings( defaultFileName(), QSettings::IniFormat ).value( key, def ).toBool();
+    return SETTINGS.value( key, def ).toBool();
 }
 
 
@@ -106,7 +119,7 @@ QString DInsightConfig::getLocalizedKey( const QString& key )
 
 void    DInsightConfig::set( const QString& key, const QString& value )
 {
-    QSettings( defaultFileName(), QSettings::IniFormat ).setValue( key, value );
+    SETTINGS.setValue( key, value );
 }
 
 


### PR DESCRIPTION
The code currently uses two different configuration files, the Qt
native one to store the directory used in QPersistantFileDialog and
DInsightReportWindow, and a INI file named insight.conf for everything
else.  The first use is kept unchanged, while the latter is changed
for non-Windows builds.  Windows configuration handling is kept
unchanged to stay compatible with the already released version.  On
non-Windows platforms the code is changed to look in /usr/share/,
/etc/ and ~/.config/ for insight.ini instead of looking for
insight.conf only in the current working directory.

This bring the program more in line with Linux Filesystem Hierarcy
standard on Unix.

Note, the Qt QSettings documentation state that the native file to
look for is named insight.conf, but at least on Linux the file used by
QPersistantFileDialog and DInsightReportWindow is insightrc.  The file
used by DInsightConfig is insight.ini after this change, thus keeping
the two configuration systems in two separeate files.

This change partly addresses issue #9.