### PR TITLE
Use delete[] to free memory allocated using new char[]

### DIFF
--- a/src/gui/dtreeitem.cpp
+++ b/src/gui/dtreeitem.cpp
@@ -459,7 +459,7 @@ void DTreeRootItem::deleteChildren()
             p->~DTreeItem();
             p++;
         }
-        delete (char*)*it;             
+        delete[] (char*)*it;
         it++;
     }
 
@@ -473,7 +473,7 @@ void DTreeRootItem::deleteChildren()
             p->~DLeafNode();
             p++;
         }
-        delete (char*)*itL;             
+        delete[] (char*)*itL;
         itL++;
     }
 


### PR DESCRIPTION
Fix issue discovered using valgrind.  The delete operator used during
program exit did not match the new operator used during program
startup and loading.